### PR TITLE
Add branch alias for master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,5 +21,10 @@
     },
     "autoload": {
         "psr-0": { "Bdt\\Clickatell": "src/" }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.0.x-dev"
+        }
     }
 }


### PR DESCRIPTION
Added a branch alias to your repository to allow users to depend on 2.0.*@dev rather than having to use dev-master.

For more information about why this is a good thing: https://igor.io/2013/01/07/composer-versioning.html
